### PR TITLE
Add dependencies back. Add bin back. Change bin name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ Based on svg-to-react-cli.
 A command line utility that takes a svg image file and outputs a fully formatted stateless functional React Native component with `height` and `width` for props. With flags to toggle formatting and remove style attributes.
 
 ## To Use
-`npm install -g svg-to-react-naive-cli`
+`npm install -g svg-to-react-native-cli`
 
 ### One File
 
-`svg-to-react-native src/svg/images/logo Logo --output ./src/svg/components/`
+`svg-to-rn src/svg/images/logo Logo --output ./src/svg/components/`
 
 **NOTE**: image file must be in current working directory. Do not add the extension. If file is `image.svg`, then just enter `image` as the first argument. ComponentName will be the name of the sfc and filename with `.js` appended.
 

--- a/package.json
+++ b/package.json
@@ -23,5 +23,15 @@
   "bugs": {
     "url": "https://github.com/chrisbull/svg-to-react-native-cli/issues"
   },
-  "homepage": "https://github.com/chrisbull/svg-to-react-native-cli#readme"
+  "homepage": "https://github.com/chrisbull/svg-to-react-native-cli#readme",
+  "bin": {
+    "svg-to-rn": "./index.js"
+  },
+  "dependencies": {
+    "chalk": "^1.1.3",
+    "htmltojsx": "^0.3.0",
+    "jsdom-no-contextify": "^3.1.0",
+    "svg-to-jsx": "^0.0.21",
+    "yargs": "^6.5.0"
+  }
 }


### PR DESCRIPTION
For some reason, dependencies and bin were removed from package.json two
commits ago. This commit adds them back in.

Update README.md to remove typo in install line:
```
npm install -g svg-to-react-naive-cli
```

Change name of node executable link to `svg-to-rn` because the other was
too much to type.